### PR TITLE
Add URL extension to the switcher links

### DIFF
--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -3,7 +3,7 @@
 {% if key == langswitcher.current %}
 	{% set lang_url = page.url %}
 {% else %}
-	{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route ?: '/' %}
+	{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route~page.urlExtension ?: '/' %}
 {% endif %}
 <link rel="alternate" hreflang="{{ key }}" href="{{ lang_url ~ uri.params }}" />
 {% endfor %}

--- a/templates/partials/langswitcher.html.twig
+++ b/templates/partials/langswitcher.html.twig
@@ -7,7 +7,7 @@
         {% set lang_url = page.url %}
         {% set active_class = ' active' %}
     {% else %}
-        {% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route ?: '/' %}
+        {% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route~page.urlExtension ?: '/' %}
         {% set active_class = '' %}
     {% endif %}
 


### PR DESCRIPTION
When the `page.append_url_extension` option is set, in the switcher the link to the active page has an extension while the other links don't.