### PR TITLE
FIX: comply with the "hide home route in URLs" option in system.yml

### DIFF
--- a/langswitcher.php
+++ b/langswitcher.php
@@ -60,7 +60,7 @@ class LangSwitcherPlugin extends Plugin
         $data = new \stdClass;
 
         $page = $this->grav['page'];
-        $data->page_route = $page->rawRoute();
+        $data->page_route = $page->Route();
         if ($page->home()) {
             $data->page_route = '/';
         }


### PR DESCRIPTION
raw Route gives an url like `/blog/myarticle` instead of `/myarticle` if the setting `Hide home route in URLs` in the settings is active.