### PR TITLE
Slug-support in hreflang tags

### DIFF
--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -1,8 +1,11 @@
+{% set default_language = grav['language'].getDefault() %}
+{% set default_language_url = null %}
+
 {% for language in langswitcher.languages %}
 
     {% set show_language = true %}
 
-    {% if language == langswitcher.current %}
+    {% if language == langswitcher.current %} 
         {% set lang_url = page.url %}
     {% else %}
 
@@ -31,9 +34,15 @@
         
     {% endif %}
 
+    {% if default_language == language %}
+      {% set default_language_url = (lang_url ~ uri.params) | regex_replace('#/$#', '') %}
+    {% endif %}
+
     {% if show_language %}
         <link rel="alternate" hreflang="{{ language }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') }}" />
     {% endif %}
 {% endfor %}
 
-<link rel="alternate" hreflang="x-default" href="/{{ grav['language'].getDefault() ?: 'en' }}" />
+{% if default_language_url != null %}
+  <link rel="alternate" hreflang="x-default" href="{{ default_language_url }}" />
+{% endif %}

--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -1,9 +1,11 @@
 {% set langobj = grav['language'] %}
 {% for key in langswitcher.languages %}
 {% if key == langswitcher.current %}
-	{% set lang_url = page.url %}
+{% set lang_url = page.url %}
 {% else %}
-	{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key) ~ langswitcher.page_route ~ page.urlExtension ?: '/' %}
+{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key) ~ langswitcher.page_route ~ page.urlExtension ?:
+'/' %}
 {% endif %}
-<link rel="alternate" hreflang="{{ key }}" href="{{ lang_url ~ uri.params }}" />
+<link rel="alternate" hreflang="{{ key }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') }}" />
 {% endfor %}
+<link rel="alternate" hreflang="x-default" href="/{{ langObj.getDefault() ?: 'en' }}" />

--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -39,7 +39,7 @@
     {% endif %}
 
     {% if show_language %}
-        <link rel="alternate" hreflang="{{ language }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') }}" />
+        <link rel="alternate" hreflang="{{ language }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') | regex_replace('#/home$#', '') }}" />
     {% endif %}
 {% endfor %}
 

--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -1,11 +1,39 @@
-{% set langobj = grav['language'] %}
-{% for key in langswitcher.languages %}
-{% if key == langswitcher.current %}
-{% set lang_url = page.url %}
-{% else %}
-{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key) ~ langswitcher.page_route ~ page.urlExtension ?:
-'/' %}
-{% endif %}
-<link rel="alternate" hreflang="{{ key }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') }}" />
+{% for language in langswitcher.languages %}
+
+    {% set show_language = true %}
+
+    {% if language == langswitcher.current %}
+        {% set lang_url = page.url %}
+    {% else %}
+
+        {% set base_lang_url = base_url_simple ~ grav.language.getLanguageURLPrefix(language) %}
+
+        {% set lang_url = base_lang_url ~ langswitcher.page_route ~ page.urlExtension %}
+
+        {% set untranslated_pages_behavior = grav.config.plugins.langswitcher.untranslated_pages_behavior %}
+        {% if untranslated_pages_behavior != 'none' %}
+            {% set translated_page = langswitcher.translated_pages[language] %}
+
+            {% if (not translated_page) or (not translated_page.published) %}
+
+                {% if untranslated_pages_behavior == 'redirect' %}
+                    {% set lang_url = base_lang_url ~ '/' %}
+                {% elseif untranslated_pages_behavior == 'hide' %}
+                    {% set show_language = false %}
+                {% endif %}
+
+            {% else %}
+
+                {% set lang_url = base_lang_url ~ '/' ~ langswitcher.translated_page_routes[language] %}
+
+            {% endif %}
+        {% endif %}
+        
+    {% endif %}
+
+    {% if show_language %}
+        <link rel="alternate" hreflang="{{ language }}" href="{{ (lang_url ~ uri.params) | regex_replace('#/$#', '') }}" />
+    {% endif %}
 {% endfor %}
-<link rel="alternate" hreflang="x-default" href="/{{ langObj.getDefault() ?: 'en' }}" />
+
+<link rel="alternate" hreflang="x-default" href="/{{ grav['language'].getDefault() ?: 'en' }}" />

--- a/templates/partials/langswitcher.html.twig
+++ b/templates/partials/langswitcher.html.twig
@@ -18,6 +18,8 @@
                     {% set show_language = false %}
                 {% endif %}
             {% endif %}
+        {% else %}
+            {% set lang_url = base_lang_url ~ '/' ~ langswitcher.translated_page_routes[language] %}
         {% endif %}
         {% set active_class = '' %}
     {% endif %}

--- a/templates/partials/langswitcher.html.twig
+++ b/templates/partials/langswitcher.html.twig
@@ -17,15 +17,15 @@
                 {% elseif untranslated_pages_behavior == 'hide' %}
                     {% set show_language = false %}
                 {% endif %}
+            {% else %}
+                {% set lang_url = base_lang_url ~ '/' ~ langswitcher.translated_page_routes[language] %}
             {% endif %}
-        {% else %}
-            {% set lang_url = base_lang_url ~ '/' ~ langswitcher.translated_page_routes[language] %}
         {% endif %}
         {% set active_class = '' %}
     {% endif %}
 
     {% if show_language %}
-        <li><a href="{{ lang_url ~ uri.params }}" class="external{{ active_class }}">{{ native_name(language)|capitalize }}</a></li>
+        <li><a href="{{ lang_url ~ uri.params | regex_replace('#/$#', '') }}" class="external{{ active_class }}">{{ native_name(language)|capitalize }}</a></li>
     {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
These changes will make sure that the right language-specific slugs are generated in the hreflang-tags. 
Additionally, the plugin now also generates an x-default hreflang tag. 