### PR TITLE
Route localization attempt based on the translated slugs

### DIFF
--- a/templates/partials/langswitcher.html.twig
+++ b/templates/partials/langswitcher.html.twig
@@ -7,7 +7,8 @@
         {% set active_class = ' active' %}
     {% else %}
         {% set base_lang_url = base_url_simple ~ grav.language.getLanguageURLPrefix(language) %}
-        {% set lang_url = base_lang_url ~ langswitcher.page_route ~ page.urlExtension %}
+        {#% set lang_url = base_lang_url ~ langswitcher.page_route ~ page.urlExtension %#}
+        {% set lang_url = base_lang_url ~ langswitcher.translated_routes[language] ~ page.urlExtension %}
         {% set untranslated_pages_behavior = grav.config.plugins.langswitcher.untranslated_pages_behavior %}
         {% if untranslated_pages_behavior != 'none' %}
             {% set translated_page = langswitcher.translated_pages[language] %}


### PR DESCRIPTION
Using custom slugs if found through the translated markdowns of the pages hierarchy... this should lead to a better SEO for multilanguage websites