### PR TITLE
Fix multilang alternates

### DIFF
--- a/templates/partials/langswitcher.hreflang.html.twig
+++ b/templates/partials/langswitcher.hreflang.html.twig
@@ -1,9 +1,9 @@
 {% set langobj = grav['language'] %}
 {% for key in langswitcher.languages %}
 {% if key == langswitcher.current %}
-	{% set lang_url = page.url %}
+	{% set lang_url = page.url is same as('/') ? '' : page.url %}
 {% else %}
-	{% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key) ~ langswitcher.page_route ~ page.urlExtension ?: '/' %}
+	{% set lang_url = (langobj.getLanguageURLPrefix(key) ~ langswitcher.page_route ~ page.urlExtension ?: '')|rtrim('/') %}
 {% endif %}
-<link rel="alternate" hreflang="{{ key }}" href="{{ base_url_absolute ~ lang_url ~ uri.params }}" />
+<link rel="alternate" hreflang="{{ key }}" href="{{ uri.base ~ lang_url ~ uri.params }}" />
 {% endfor %}


### PR DESCRIPTION
This is an addition to #57 to fix [this issue](https://github.com/getgrav/grav-plugin-langswitcher/pull/57#issuecomment-801443366)
Also fixes so that switching languages would not alternate the trailing slash (removes it)