### PR TITLE
file path fallback for default language (fixes #67)

### DIFF
--- a/langswitcher.php
+++ b/langswitcher.php
@@ -126,6 +126,9 @@ class LangSwitcherPlugin extends Plugin
                 $translated_pages[$language] = null;
                 $page_name_without_ext = substr($page->name(), 0, -(strlen($page->extension())));
                 $translated_page_path = $page->path() . DS . $page_name_without_ext . '.' . $language . '.md';
+                if (!file_exists($translated_page_path) and $language == $this->grav['language']->getDefault()) {
+                    $translated_page_path = $page->path() . DS . $page_name_without_ext . '.md';
+                }
                 if (file_exists($translated_page_path)) {
                     $translated_page = new Page();
                     $translated_page->init(new \SplFileInfo($translated_page_path), $language . '.md');


### PR DESCRIPTION
This PR attempts to resolve #67. 

Here is the rationalization: 

In the [twig file](https://github.com/getgrav/grav-plugin-langswitcher/blob/2.0.1/templates/partials/langswitcher.html.twig), you can see that a language link is shown only if the `show_language` variable is not false. (line 26).
This variable is set to false if, in particular, `translated_page` is false and `untranslated_pages_behavior == 'hide'` (lines 15 and 18). The former variable is set in the line above (14):
 `translated_page = langswitcher.translated_pages[language]`
This array is defined in the [php file](https://github.com/getgrav/grav-plugin-langswitcher/blob/2.0.1/langswitcher.php), lines 123-135. 
In line 126, `$translated_pages[$language]` gets defined as `null`, and is only redefined (in line 132) under the condition (line 129) that `file_exists($translated_page_path)`. This variable is defined in the previous line as follows: 
`$translated_page_path = $page->path() . DS . $page_name_without_ext . '.' . $language . '.md';`
Ignoring the rest of the line, we see that `$language` is _hardcoded_ into the file path. However, the very point of `include_default_lang_file_extension` being set to `false`, is that in this case, for the default language, the language code will _not_ appear in the file path, and so `$translated_page_path` will _necessarily_ be set to a nonexistent file path and `$translated_pages[$language]` will remain `null`, so `translated_page` will be set to `null` in the twig file and the default language will never appear in the language switcher (unless it's the active page)!

My patch attempts to fix this by checking if the path with the language extension exists, and, if not, and if the given language is the default language, redefining the path as not including the language extension.