### PR TITLE
Always fall back to default slug instead of failing 

### DIFF
--- a/langswitcher.php
+++ b/langswitcher.php
@@ -91,9 +91,12 @@ class LangSwitcherPlugin extends Plugin
                         array_unshift($translated_url_parts, $untranslated_slug);
                     }
                 }
-                $current_node = $current_node->parent();
-                $path = dirname($path);
+            } else {
+                array_unshift($translated_url_parts, $current_node->slug());
             }
+            $current_node = $current_node->parent();
+            $path = dirname($path);
+            
             $max_recursions--;
         }
         if (!empty($translated_url_parts)) {


### PR DESCRIPTION
Intented to fix #69
See analysis [in this comment](https://github.com/getgrav/grav-plugin-langswitcher/issues/69#issuecomment-1214467335) and the recap after that.

The recursion to find translated slug path fails if at first a translated file is found, but then at some point in the recursion, a translated file is missing at that level. 
(If the missing file is right at the beginning, the failure doesn't happen because of the code [here ](https://github.com/getgrav/grav-plugin-langswitcher/blob/a9c5d1a2328f71064e849881682164d88d7b86d5/langswitcher.php#L141 ) which falls back to page route. )

For my own purposes I think it would have been good enough to add 
```
} else {
   return '';
}
```
at the end of the `if (file_exists($translated_md_filepath))` block (and I think the code would have been no worse off than before), but trying to make it work better in other cases to my own, I tried to keep going down the path, and _at each level_
falling back to the default slug instead of a translated slug. I believe this will allow certain folders along the path to have translated slugs without requiring all of them to have a translated version.

That said I don't really have experience with translated slugs so someone who knows more about them should have a look at this. But the plugin in its current state completely breaks my links in the langswitcher for the reasons outlined in the comment linked above. 

CC: @flagar @rhukster @godfatherjohn