### PR TITLE
New config param: hide_active

### DIFF
--- a/langswitcher.yaml
+++ b/langswitcher.yaml
@@ -3,3 +3,4 @@ built_in_css: true
 translated_urls: true
 untranslated_pages_behavior: none
 language_display: long
+hide_active: true

--- a/templates/partials/langswitcher.html.twig
+++ b/templates/partials/langswitcher.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block language_item %}
-    {% if show_language %}
+    {% if show_language and not (active_class and grav.config.plugins.langswitcher.hide_active) %}
     <li><a href="{{ lang_url ~ uri.params ~ (uri.query|length > 1 ? '?' ~ uri.query) }}" class="external {{ active_class }}">{% include 'partials/langswitcher-' ~ display_format ~ '.html.twig' %}</a></li>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
I suggest this simple new config boolean 'hide_active' param to hide the active language from the menu.